### PR TITLE
deploy only on main #67

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,11 @@ concurrency:
 
 jobs:
   lint:
+    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/lint.yml
 
   build:
+    if: github.ref == 'refs/heads/main'
     needs: lint
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +56,7 @@ jobs:
           path: site
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: build
     environment:
       name: github-pages
@@ -65,6 +68,7 @@ jobs:
         uses: actions/deploy-pages@v5
 
   build-pdfs:
+    if: github.ref == 'refs/heads/main'
     needs: deploy
     permissions:
       contents: write


### PR DESCRIPTION
## Cosa cambia

In merito a #67 ho iniziato a fare delle lavorazioni, capiamo se magari far fare solo alcuni step tipo il linting ai branch ma non il deploy e il generate pdf

## Checklist

- [X] Ho formattato i file Markdown con `make lint-fix` o `mdformat --extensions space_control --no-validate`.
- [X] Ho evitato tab e spazi finali.
- [X] Ho verificato la formattazione con `make lint` o con `mdformat --extensions space_control --check docs/ README.md CONTRIBUTING.md`.
- [X] Se ho aggiunto o rinominato pagine, ho aggiornato anche `mkdocs.yml`.
