### PR TITLE
Fix posizione testimonianza, aggiunto credits testimonianza precedente.

### DIFF
--- a/docs/laurea-magistrale/ingegneria-telecomunicazioni.md
+++ b/docs/laurea-magistrale/ingegneria-telecomunicazioni.md
@@ -31,7 +31,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 **<u>2025 2026</u>**
 
-- Anonimo
+- DomHeadroom
     - a che livelli possiamo fare un attacco e quali sono i costi
     - quali sono gli attacchi a livello software
     - perché è meglio usare protocolli standard rispetto quelli custom
@@ -49,7 +49,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 **<u>2025 2026</u>**
 
-- Anonimo
+- DomHeadroom
     - parlare di jtag come funziona quali sono i pin e a cosa serve
     - come vengono collegati i chip spi e le due configurazioni
     - come faccio a sapere quando arrivano i dati allo slave in una configurazione daisy chain
@@ -60,7 +60,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 **<u>2025 2026</u>**
 
-- Anonimo
+- DomHeadroom
     - come riconosci un EPROM, quali sono i pin di un EPROM SPI
     - a cosa serve il marcatore sui chip integrati
     - come collegarsi agli spi, mqtt è un protocollo affidabile?

--- a/docs/laurea-triennale/ingegneria-informatica.md
+++ b/docs/laurea-triennale/ingegneria-informatica.md
@@ -3406,6 +3406,8 @@ malloc(sizeof(int)*(i+1));
 
 ## Laboratorio di ricerca operativa
 
+### Marcello Sammarra
+
 **<u>2024 2025</u>**
 
 - DomHeadroom
@@ -3413,8 +3415,6 @@ malloc(sizeof(int)*(i+1));
     - validità del secondo e primo corollario del teorema della dualità nella rete di flusso
     - parlare del problema di branch and bound
     - ottimizzazioni applicate nel branch and bound (taglio di un ramo)
-
-### Marcello Sammarra
 
 **<u>2021 2022</u>**
 


### PR DESCRIPTION
## Cosa cambia

Ho corretto la posizione della testimonianza di laboratorio di ricerca operativa che era sopra il nome del professore,
aggiunto credits a testimonianza mia, prove:
<img width="616" height="521" alt="immagine" src="https://github.com/user-attachments/assets/28c44986-74cf-4d43-91d7-2fae9c920902" />
(non mi entra tutto il messaggio nello screen)

## Checklist

- [x] Ho formattato i file Markdown con `make lint-fix` o `mdformat --extensions space_control --no-validate`.
- [x] Ho evitato tab e spazi finali.
- [x] Ho verificato la formattazione con `make lint` o con `mdformat --extensions space_control --check docs/ README.md CONTRIBUTING.md`.
- [ ] Se ho aggiunto o rinominato pagine, ho aggiornato anche `mkdocs.yml`.
