### PR TITLE
Fixato errori di battitura e stile del testo

### DIFF
--- a/.github/ISSUE_TEMPLATE/aggiunta-testimonianza.md
+++ b/.github/ISSUE_TEMPLATE/aggiunta-testimonianza.md
@@ -13,7 +13,7 @@ assignees: ''
 
 ### Professore con cui si è svolto l'esame - es: Furfaro Angelo
 
-#### anno di riferimento ( quello di settembre ) - es: 2018/2019
+#### anno di riferimento ( quello di settembre ) - es: 2018 2019
 
 - NOME ESAMINANDO oppure Anonimi
     - domanda 1

--- a/.github/ISSUE_TEMPLATE/correzione-di-una-testimonianza.md
+++ b/.github/ISSUE_TEMPLATE/correzione-di-una-testimonianza.md
@@ -13,7 +13,7 @@ assignees: ''
 
 ### Professore con cui si è svolto l'esame - es: Furfaro Angelo
 
-#### anno di riferimento ( quello di settembre ) - es: 2018/2019
+#### anno di riferimento ( quello di settembre ) - es: 2018 2019
 
 - NOME ESAMINANDO oppure Anonimi
     - domanda o domande da correggere

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ L'indice viene automaticamente creato da MkDocs
 #### Alcuni consigli di buona scrittura
 
 - Lasciare almeno un rigo vuoto tra un titolo e un altro
-- meglio utilizzare gli elenchi puntati per dividere una testimonianza da un altra
+- meglio utilizzare gli elenchi puntati per dividere una testimonianza da un'altra
 - meglio utilizzare codice inline o grassetto
 
 Grazie per il tuo contributo!

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ L'intera struttura è basata su più file, uno a corso di laurea:
 
 - [LT Ingegneria Informatica](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/docs/laurea-triennale/ingegneria-informatica.md)
 - [LT Ingegneria Elettronica](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/docs/laurea-triennale/ingegneria-elettronica.md)
+- [LT Ingegneria Biomedica](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/docs/laurea-triennale/ingegneria-biomedica.md)
 - [LT Ingegneria Alimentare](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/docs/laurea-triennale/ingegneria-alimentare.md)
 - [LM Ingegneria Informatica](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/docs/laurea-magistrale/ingegneria-informatica.md)
 - [LM Ingegneria Elettronica](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/docs/laurea-magistrale/ingegneria-elettronica.md)

--- a/docs/laurea-magistrale/ingegneria-automazione.md
+++ b/docs/laurea-magistrale/ingegneria-automazione.md
@@ -1,10 +1,10 @@
-# Indice delle domande degli esami orali: Ingegneria dell' Automazione
+# Indice delle domande degli esami orali: Ingegneria dell'Automazione
 
-Questo file contiene le testimonianze degli esami orali di vari studenti del corso di laurea in **Ingegneria Ingegneria dell' Automazione Laurea Magistrale** all' **Unical** ( *Università della Calabria* ) e fa parte del progetto [Indice Argomenti Orali](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale) gestito dall'organizzazione **UnicalLoveTelegram**
+Questo file contiene le testimonianze degli esami orali di vari studenti del corso di laurea in **Ingegneria dell'Automazione Laurea Magistrale** all' **Unical** ( *Università della Calabria* ) e fa parte del progetto [Indice Argomenti Orali](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale) gestito dall'organizzazione **UnicalLoveTelegram**
 
 Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOrale/blob/main/README.md) per conoscere tutti i dettagli del progetto, sapere come partecipare e come sfogliare tutto il nostro materiale!
 
-- [Indice delle domande degli esami orali: Ingegneria dell' Automazione](#indice-delle-domande-degli-esami-orali-ingegneria-dell-automazione)
+- [Indice delle domande degli esami orali: Ingegneria dell'Automazione](#indice-delle-domande-degli-esami-orali-ingegneria-dell-automazione)
     - [Teoria dei sistemi](#teoria-dei-sistemi)
         - [Casavola](#casavola)
 

--- a/docs/laurea-magistrale/ingegneria-informatica.md
+++ b/docs/laurea-magistrale/ingegneria-informatica.md
@@ -239,7 +239,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - Spiegazione csrf
     - Differenze tra csrf e xss
     - Cos'è kerberos
-    - challenge SSRF presente sul sito di [burp suite](https://portswigger.net/burp) (in teoria vi registrate, andate in accademy e poi nei vulnerabilty lab e cercate ssrf)
+    - challenge SSRF presente sul sito di [burp suite](https://portswigger.net/burp) (in teoria vi registrate, andate in academy e poi nei vulnerability lab e cercate ssrf)
     - pass the hash: descrizione
     - challenge presente su natas [numero 8](https://overthewire.org/wargames/natas)
     - Hash md5: come si riconosce?
@@ -248,7 +248,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
         - pass the ticket
         - comandi vari del prompt o powershell
         - rogue potato (e in generale da tenere sott'occhio qualsiasi cosa che sia potato, quindi juicy potato, hot potato...)
-        - si hanno degli output di eseguibili di Windows (permessi di un eseguibile e le info di un eseguibile) e fra i permessi di questo eseguibile c'era gitconfig e si poteva cambiare la configurazione per cambiare il /bin/path con una reverse shell
+        - si hanno degli output di eseguibili di Windows (permessi di un eseguibile e le info di un eseguibile) e fra i permessi di questo eseguibile c'era git config e si poteva cambiare la configurazione per cambiare il /bin/path con una reverse shell
         - query su un registro per vedere se era attivo il permesso su un utente (alwaysinstalledprivileged) e si poteva sfruttare per installare qualsiasi eseguibile come utente privilegiato
         - pass the hash
         - bind e reverse shell
@@ -289,7 +289,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - sql injection con script php (cosa è e cosa fa)
     - challenge web con loose comparison
     - differenze attacchi x32 bit e x64 bit
-        - rop chain e bruteforce sul indirizzo di ritorno
+        - rop chain e bruteforce sull'indirizzo di ritorno
     - Metasploit cosa è
     - tool simili a metasploit per windows
     - challenge web che presentava degli endpoint e bisognava loggarsi come admin
@@ -382,7 +382,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
         - SYN SCAN
     - ret2libc
         - perché è meno conveniente rispetto alla code reuse?
-            - Perchè ret2libc non può essere utilizzata in caso di chiamate a due o più funzioni che posseggono uno o più parametri, mentre la code reuse sì
+            - Perché ret2libc non può essere utilizzata in caso di chiamate a due o più funzioni che posseggono uno o più parametri, mentre la code reuse sì
     - Plt e got
     - Xss
     - Canary
@@ -400,7 +400,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 - Anonimi
     - Canary
     - gdb
-    - sito che ritorna un immagine, come capisci le tabelle?
+    - sito che ritorna un'immagine, come capisci le tabelle?
     - nmap port scanning
         - fin scan
         - udp scan
@@ -432,7 +432,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - gerarchie dinamiche
     - a cosa serve attributo master nello scenario di verità storica
     - a cosa servono le chiavi surrogate
-    - perchè non si usano i btree
+    - perché non si usano i btree
     - star index
     - join index
     - quando conviene fare snow flake
@@ -460,7 +460,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - la valutazione comprende i punteggi dati al test online di fine corso (crocette) e i lavori in ppt di gruppo
     - Stakeholder amichevoli
     - Outsourcing
-    - Finalitá dell azienda
+    - Finalità dell'azienda
 
 ## Modelli e Tecniche per i Big Data
 
@@ -499,25 +499,25 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - RDD
     - hama
     - costo del calcolo bsp
-    - zookeper
+    - ZooKeeper
     - trajectory discovery
     - java stream lazy
-    - legge amdhal
+    - legge di Amdahl
     - wordcount
     - mapper e reducer
     - spark e hadoop convenienza
     - bsp in generale
-    - send receive non blocanti e bloccanti
+    - send receive non bloccanti e bloccanti
     - spark lazy execution
     - wordcount reverse (chiave lunghezza parole)
     - logica di hive
-    - legge di amdhal
+    - legge di Amdahl
     - comunicazione in MPI sincrona e asincrona e meccanismi
     - caratteristiche di un programma in parallelo
     - combiner in mapreduce
     - numero di reducer e mapper
     - watermark
-    - wordlenghtcount
+    - wordlengthcount
 - Anonimi
     - codice word count
     - che tipologia di programmi esegue storm
@@ -604,9 +604,9 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - conflitti sui dati pipeline
     - emissione fuori ordine
     - Rsr
-    - completamente ofuori ordine
+    - completamente fuori ordine
     - ritiro in ordine
-    - confliti sul controllo
+    - conflitti sul controllo
     - predizione dei salti a schema - branch prediction unità
     - statistica a due bit con automa
     - conflitti sulle super scalari
@@ -671,8 +671,8 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - disegno
     - speculazione hardware macchina super scalare
     - differenza uma e numa
-    - macchina hasswell
-    - differenze cics e risc
+    - macchina Haswell
+    - differenze CISC e RISC
     - principi di progettazione risc
     - riduzione parallela
     - rsr
@@ -725,7 +725,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - cos'è un automa a pila
 - Marco Domenicano
     - Tautologia
-    - conraddizione
+    - contraddizione
     - memorizzazione di un json in calculista
     - esercizio del minimo locale in calculist e prolog
 - Anonimi
@@ -880,10 +880,10 @@ rc(X):- u(X), not(r(X)).
 
 - Angelo
     - definizione di problema np-completo
-    - cos' é una trasformazione polinomiale?
+    - cos'è una trasformazione polinomiale?
     - dimostrazione del teorema di Rice
     - fixed parameter trattability
-    - cos' é uno schema di approssimazione polinomiale ?
+    - cos'è uno schema di approssimazione polinomiale?
     - dimostrare che nap-sack é np-hard
     - perché usiamo trasformazioni polinomiali e non esponenziali?
     - dimostrare che ld é ricorsivamente enumerabile
@@ -896,9 +896,9 @@ rc(X):- u(X), not(r(X)).
 - Anonimi
     - cook
     - NP dentro PSpace (dimostrazione)
-        - **Risposta**: Perchè la definizione di NP dice che NP appartiene a Ptime, poichè Ptime è un sottoinsieme di Pspace allora anche NP è un sottoinsieme di Pspace
+        - **Risposta**: Perché la definizione di NP dice che NP appartiene a Ptime, poiché Ptime è un sottoinsieme di Pspace allora anche NP è un sottoinsieme di Pspace
     - teorema di Rice
-    - np completo (definizione) e vantaggi nellúso
+    - np completo (definizione) e vantaggi nell'uso
     - Teorema di Cook
     - Definizione di problema NP-complete
     - Domanda: `come cambia la clas shortcut multicursorsse np complete se cambiamo la definizione di hardness considerando trasformazioni esponenziali`
@@ -911,7 +911,7 @@ rc(X):- u(X), not(r(X)).
     - mostrazione Indipendent SET
     - Knapsack intero e frazionario
     - subset sum
-    - Approssimabilità knpasack (algoritmo pseudo polinomiale e FPTAS)
+    - Approssimabilità knapsack (algoritmo pseudo polinomiale e FPTAS)
     - importanza della riduzione polinomiale tra problemi decisionali
     - complessità parametrizzata con definizione di xp e di ffpt
     - problema np ha come definizione NP = `{L| E R polinomialmente decidibile e bilanciata che caratterizza L}` con PI1 R=L (dimostrazione)
@@ -932,7 +932,7 @@ rc(X):- u(X), not(r(X)).
     - Definizione NP
     - Definizione NP Hard
     - Definizione NP Complete
-    - Dimostrazioen indecidibilità Lu e non appartenenza a RE di Ld
+    - Dimostrazione indecidibilità Lu e non appartenenza a RE di Ld
     - Importanza riduzione polinomiale tra problemi decisionali
     - Perché NP è incluso in PSpace con dimostrazione
     - complessità parametrizzata con definizione di XP e FP
@@ -1042,7 +1042,7 @@ rc(X):- u(X), not(r(X)).
 - Anonimo 9
     - esempio di problema in sigma p 2
     - definizione della classe NC
-    - teorema di savitch
+    - teorema di Savitch
     - teorema di Mayer
     - definizione della classe IP
     - dimostrazione di NPSPACE contenuto in EXPTIME
@@ -1117,15 +1117,15 @@ rc(X):- u(X), not(r(X)).
     - quanti simboli leggo per volta?
     - c è differenza di potenza di calcolo tra dfa e nfa? no, ma c'è differenza di? (risposta: taglia, dimensione, numero di stati)
     - teorema di rice con dimostrazione
-    - teorema di savitch con dimostrazione
+    - teorema di Savitch con dimostrazione
     - parliamo del concetto di approssimabilità
     - i problemi sono tutti approssimabili?
     - cos'è la classe p/poly
     - classe di complessità IP
-    - legame che c'è tra complessita di circuito e di tempo nei linguaggi
+    - legame che c'è tra complessità di circuito e di tempo nei linguaggi
     - un insieme r.e. lo possiamo definire in più modi, come e in che modo sono equivalenti le def(dimostrazione che la seconda def è equivalente alla terza)
-    - cos è la forma normale di Greinbach
-    - classe di complessita NC
+    - cos'è la forma normale di Greinbach
+    - classe di complessità NC
     - confronta NCI con ACI
     - p/poly dove sta rispetto a NCI e ACI (non è sicuro sia questo confronto però è sicuro sia con p/poly)
     - nel linguaggio mini C non abbiamo l'if-than-else, riusciamo a realizzarlo?
@@ -1134,9 +1134,9 @@ rc(X):- u(X), not(r(X)).
     - consideriamo l'insieme degli indici delle funzioni totali, è ricorsivo r.e. o non r.e.
     - parliamo di p spazio e indichiamone un linguaggio completo
     - data una macchina che dati n elementi in input si vuole stabilire se il numero di elementi dell array sia pari o dispari, che complessità ha nello spazio
-    - esiste una forma normale per i problemi in psapzio che è anche la codifica di un problema completo, com è fatto
-    - domande su copspazio generiche
-    - teorema di toda (ultimo fatto nel corso)
+    - esiste una forma normale per i problemi in PSPACE che è anche la codifica di un problema completo, com è fatto
+    - domande su coPSPACE generiche
+    - teorema di Toda (ultimo fatto nel corso)
     - dimostriamo che un automa a pila deterministico è sempre equivalente a uno a pila non deterministico, non è così in realtà, mi fai vedere un linguaggio che separa?
     - consideriamo ww^R perché l automa a pila det non è sufficiente in questo caso, dimostrazione
     - Abbiamo due forme di automi a pila accettanti per stato finale e per stato vuoto, dimostrazione equivalenza che i linguaggi riconosciuti da uno sono "equivalenti" a quelli dell altro
@@ -1278,7 +1278,7 @@ rc(X):- u(X), not(r(X)).
         - hill climbing + simulated annealing
         - pac learning
     - Anonime
-        - IDA\* perchè c'è min nella funzione
+        - IDA\* perché c'è min nella funzione
         - Frame assension
         - strips
             - risoluzioni
@@ -1322,7 +1322,7 @@ rc(X):- u(X), not(r(X)).
     - Dimosrrazione dell'ottimalitá di A\* graph search
 - Anonimo 3
     - Algoritmo yannakaki
-    - Complessita dell'algoritmo di yannakaki
+    - Complessità dell'algoritmo di yannakaki
 - Anonimo 4
     - Dimostrazione che se è ammissibile euristica allora a star è ottimale
     - Dimostrazione che euristica consistente implica ammissibile
@@ -1380,7 +1380,7 @@ rc(X):- u(X), not(r(X)).
     - problemi binari o con arità maggiore.
     - Cos'è un grafo?
     - Equilibrio di nash, cos'è e definizione formale.
-    - spiegazione di a\*, perchè è ottimale?
+    - spiegazione di a\*, perché è ottimale?
     - Cos'è l'ammissibilità?
     - Depth first search
 - Anonimo 4:
@@ -1516,14 +1516,14 @@ rc(X):- u(X), not(r(X)).
             - a cosa serve il min?
         - programma datalog stratificato
     - altri
-        - Verie testimonianze 04/02/2021
+        - Varie testimonianze 04/02/2021
         - Descrizione algoritmo Iterative deepening
         - Precisare come si può uscire dal ciclo quando non ci sono goal
             - **Risposta**: la soluzione proposta dal prof è quella di utilizzare una variabile booleana (non sappiamo nel dettaglio come), un'altra soluzione è quella di uscire quando il cutting level sia pari all'altezza dell'albero ma costa troppo in termini temporali
         - Complessità di verificare la coerenza di una teoria in logica di default (ossia se ammette un'estensione), dimostrare almeno intuitivamente perché tale problema è almeno NP-hard
             - **Risposta**: intuitivamente se la complessità dell'entailment è CONP-c in logica proposizionale, poiché la logica di default ha sia una teoria proposizionale W che un'insieme di default D è facile capire che sarà almeno difficile quanto l'entailment è quindi ha almeno una sorgente di esponenzialità
         - Strips genera stati inconsistenti?
-            - **Risposta**:un esempio è {f, not(f)} in cui abbiamo uno stato con due fluenti con valore logico opposto, ma strips NON è un linguaggio logico, f e not f potrebbero essere chiamati pluto e paperino quindi no, non genera stati inconsistenti in quanto il concetto di incosistenza è associato a linguaggi logici)
+            - **Risposta**:un esempio è {f, not(f)} in cui abbiamo uno stato con due fluenti con valore logico opposto, ma strips NON è un linguaggio logico, f e not f potrebbero essere chiamati pluto e paperino quindi no, non genera stati inconsistenti in quanto il concetto di incosistenza è associato a linguaggi logici
         - Esempio di teoria di default in cui non ci sia alcuna estensione che sia calcolabile con la semantica operazionale
             - **Risposta**: basta usare una teoria incoerente, {TRUE:A/¬A } è l'esempio tipico
 - Giovanni
@@ -1567,7 +1567,7 @@ rc(X):- u(X), not(r(X)).
     - Espressività dei modelli stabili (NP)
     - Sistemi di argomentazione ha voluto tutto
     - nel baf se le definizioni di COMPLETEZZA, ACCEPTED, DEFEATED ECC variano oppure no
-    - proof systems definizioni e propietà
+    - proof systems definizioni e proprietà
     - logica a tre valori e modelli stabili parziali, determinare se un modello è stabile parziale dato un programma
     - linguaggio delle dipendenze funzionali
     - magic set
@@ -1611,7 +1611,7 @@ rc(X):- u(X), not(r(X)).
     - Che cosa fa eval_rule()? Dato l'esempio, generare l'espressione in algebra relazionale.
     - Description logic in generale.
     - Linguaggio ALC, descrizione.
-    - Perchè utilizziamo la description logic? Non potremmo usare le formule del calcolo dei predicati al suo posto? La domanda scaturisce dal fatro che qualunque formula la possiamo riscrivere con formule del calcolo dei predicati (FOL), e quindi perché utilizzare description logic?
+    - Perché utilizziamo la description logic? Non potremmo usare le formule del calcolo dei predicati al suo posto? La domanda scaturisce dal fatto che qualunque formula la possiamo riscrivere con formule del calcolo dei predicati (FOL), e quindi perché utilizzare description logic?
     - Tbox e Abox
 - quarto Anonimo
     - Algoritmo naïve (la sua descrizione formale, anche ad alto livello)
@@ -1686,7 +1686,7 @@ rc(X):- u(X), not(r(X)).
     - Query In Uppaal
     - Scrivere un parcheggio in reti di petri
     - template tTransaction pTransaction delle ptpn
-    - clock di uppaall
+    - clock di UPPAAL
     - come si rappresenta uno stato nel model state graph di uppaal
     - JSemaphore
     - Parametro Lambda delle simulazioni ad attori
@@ -1868,7 +1868,7 @@ rc(X):- u(X), not(r(X)).
 - Anonimi
     - meccanismi code Azure:
         - 3 tipi di proprietà obbligatorie
-    - perché si utilizza UnicastRemoteObject.exportObject e non si usa il metodo normale (lookup e ribind)?
+    - perché si utilizza UnicastRemoteObject.exportObject e non si usa il metodo normale (lookup e rebind)?
         - il meccanismo di Java obbliga a estendere la classe e questo dovrebbe farlo ogni client (soluzione scomoda)
 
 **<u>2021 2022</u>**
@@ -1964,7 +1964,7 @@ rc(X):- u(X), not(r(X)).
     - metodi di integrazione in più dimensione e perché non si può sempre suddividere in somma di integrali come in 1 dimensione
     - condizione convergenza metodi iterativi (sistemi)
     - ordine dell’errore (sia locale che globale) in tutti i metodi sulla risoluzione delle equazioni differenziali
-    - può succedere che Jacobi converga e Gaus-Siedel diverga o viceversa?
+    - può succedere che Jacobi converga e Gauss-Seidel diverga o viceversa?
     - FARE BENE il metodo di Cavalieri-Simpson (con enfasi sul motivo per cui si fa l’ipotesi sull’ uguaglianza tra la derivata in psi e psi con tilde
     - come scegliere i nodi per evitare fenomeno Runge
     - modo migliore per calcolare la somma di tanti numeri in virgola mobile (slide Marat)
@@ -1982,21 +1982,21 @@ rc(X):- u(X), not(r(X)).
         - (Risposta: sono più semplici ma non è detto che convergano)
     - Da cosa dipende il condizionamento di un sistema lineare?
     - Cancellazione numerica e come si può evitare
-    - Prendendo un metodo iterativo qual'è la condizione della convergenza?
+    - Prendendo un metodo iterativo qual è la condizione della convergenza?
         - (Raggio spettrale (ovvero massimo degli autovalori della matrice d'iterazione) < 1)
     - Cos'è uno spazio lineare?
-    - Data una grande sequenza di numeri positivi, qual'è il migliore modo di sommarli?
+    - Data una grande sequenza di numeri positivi, qual è il migliore modo di sommarli?
         - (Risposta: ordine crescente, minor perdita d'informazioni)
-    - Quale dei metodi (Gauss e Gauss-Jordan) è il più efficente? Risposta: Il migliore è il metodo di Gauss perché ha una complessità minore
+    - Quale dei metodi (Gauss e Gauss-Jordan) è il più efficiente? Risposta: Il migliore è il metodo di Gauss perché ha una complessità minore
     - Svantaggi della formula del polinomio interpolante di LaGrange? Risposta: la complessità e non si possono aggiungere nodi senza dover ricalcolare il polinomio da capo
     - Significato di errore assoluto e relativo nell'approssimazione di un numero floating point
-    - Formula adattiva di Cavalieri-Simpson e qual'è il presupposto fatto? Risposta: la derivata quarta di f(xi) è supposta uguale all'aumentare del passo
+    - Formula adattiva di Cavalieri-Simpson e qual è il presupposto fatto? Risposta: la derivata quarta di f(xi) è supposta uguale all'aumentare del passo
     - Quali sono i metodi per la risoluzione di equazioni differenziali ordinarie? Cosa vuol dire implicito ed esplicito?
     - Residuo dei sistemi lineare? Se il residuo è piccolo cosa possiamo dire sulla soluzione?
         - Risposta: r^(k) = b - Ax^(k)
     - Se il sistema è mal condizionato il fatto che il residuo è piccolo non ci dice nulla
     - Metodi per la risoluzione di equazioni differenziali e ordine degli errori
-    - Come funzionano i metodi di integrazione numerica in più dimensioni? Perchè non si può usare la formula che trasforma un
+    - Come funzionano i metodi di integrazione numerica in più dimensioni? Perché non si può usare la formula che trasforma un
     - integrale a più dimensioni in una successione di integrali in una dimensione?
     - Metodi per la derivazione numerica
     - Estrapolazione di Richardson
@@ -2014,7 +2014,7 @@ rc(X):- u(X), not(r(X)).
     - Vantaggi e svantaggi dei metodi diretti rispetto ai metodi iterativi per la soluzione di sistemi lineari.
     - Quando i metodi diretti non sono applicabili?
         - Risposta: Quando le matrici sono di grandi dimensioni è preferibile usare il metodo di Jacobi che è parallelizzabile
-    - Metodo dei coefficenti indeterminati?
+    - Metodo dei coefficienti indeterminati?
     - Metodo del punto fisso
     - Condizione di Lipshiz e dove si applica
     - Tipi di problemi computazionali (problema diretto, inverso e di indentificazione) ed esempi
@@ -2065,7 +2065,10 @@ rc(X):- u(X), not(r(X)).
 
 - Anonimi
     - interpolazione con particolare attenzione su come si costruiscono i coefficienti con Lagrange e con Newton
-    - ⁠quadratura numerica ======= **<u>2019 2020</u>**
+    - quadratura numerica
+
+**<u>2019 2020</u>**
+
 - Giovanni Giordano
     - errore assoluto e relativo
     - estrapolazione di Richardson
@@ -2079,12 +2082,15 @@ rc(X):- u(X), not(r(X)).
 **<u>2025 2026</u>**
 
 - Anonimi
-    - problema di chauchy
+    - problema di Cauchy
     - come viene rappresentato un numero su calcolatore
     - errore assoluto e relativo
     - errore macchina
     - interpolazione
-    - derivazione numerica ⁠ - equazioni differenziali e problema di cauchy ⁠ - metodi di integrazione numerica ⁠ - sistemi lineari
+    - derivazione numerica
+    - equazioni differenziali e problema di Cauchy
+    - metodi di integrazione numerica
+    - sistemi lineari
 
 **<u>2024 2025</u>**
 
@@ -2126,9 +2132,9 @@ rc(X):- u(X), not(r(X)).
         - Proprietà delle norme.
         - Che cos’è la norma 1, norma infinito, norma 2, norma p?
     - Cosa sono le equazioni differenziali?
-    - Problema di cauchy
+    - Problema di Cauchy
     - Cosa succede nel metodo di integrazione di newton vuoi aumentare il grado del polinomio, devi ricalcolare tutto? (No)
-    - Perchè esiste sempre il polinomio di migliore approssimazione e quali sono le condizioni affinchè si verifichi ciò? (teorema di weirestrass e intervallo con tutti nodi diversi)
+    - Perché esiste sempre il polinomio di migliore approssimazione e quali sono le condizioni affinché si verifichi ciò? (teorema di Weierstrass e intervallo con tutti nodi diversi)
 
 ## Crittografia e analisi reti sociali
 
@@ -2158,22 +2164,22 @@ rc(X):- u(X), not(r(X)).
     - CBC+nonce
     - CTR
     - CTR+nonce
-    - MAC (funzionamento sicurezza e challange)
+    - MAC (funzionamento sicurezza e challenge)
     - NMac
     - PMAC
     - HMAC
     - ECBC MAC
     - PAYLOAD
-    - HASH (funzionamento sicurezza e challange)
-    - PAradosso compleanno + attacco hash (collissioni)
+    - HASH (funzionamento sicurezza e challenge)
+    - Paradosso compleanno + attacco hash (collisioni)
     - Merkle damgard
-    - Autenticazione cifrata (funzionamento sicurezza e challange)
+    - Autenticazione cifrata (funzionamento sicurezza e challenge)
     - tre tipologie costruzione autenticazione cifrata (e than m, e and m, m then e) più differenze e sicurezza
     - differenza chiave simmetrica e asimmetrica
     - principi chiave asimmetrica
     - RSA
-    - Complessità attacco RSA per scoprire chaive segreta
-    - complessita attacco RSA per un messaggio cifrato (differenza con sopra )
+    - Complessità attacco RSA per scoprire chiave segreta
+    - complessità attacco RSA per un messaggio cifrato (differenza con sopra )
     - Merkle puzzle
     - autorità di certificazione e firma digitale (molto in generale più schema)
 - Riccardo
@@ -2191,7 +2197,7 @@ rc(X):- u(X), not(r(X)).
         - euclide
         - vari problemi
     - puzzle di merkle
-    - introduzione key managment e scneari utilizzo rsa
+    - introduzione key management e scenari utilizzo rsa
 
 ## Algoritmi di Crittografia
 
@@ -2218,7 +2224,7 @@ rc(X):- u(X), not(r(X)).
     - cosa può fare l'attaccante attivo che scopre la chiave
     - fiat shamir
     - differenza tra attacco a forza bruta e attacco a forza bruta del paradosso del compleanno ( la risposta "dovrebbe essere" che lo spazio di ricerca è diverso )
-    - se l'avversario si aspetta un valore di e ma ne arriva un altro puo correggere il tiro? ( la risposta "dovrebbe essere" che non può perchè il calcolo ha complessita pari a radice modulare n )
+    - se l'avversario si aspetta un valore di e ma ne arriva un altro può correggere il tiro? ( la risposta "dovrebbe essere" che non può perché il calcolo ha complessità pari a radice modulare n )
     - 3des
     - come decifrare con 3des ( se E(k1,k2,k3,m)=E(k1,D(k2,E(k3,m))) allora D(k1,k2,k3,m)=D(k3,E(k2,D(k1,c))) )
     - attacco e complessità dell'attacco a 2des
@@ -2250,8 +2256,8 @@ rc(X):- u(X), not(r(X)).
         - problemi
         - algoritmo
     - One Time Pad
-        - decifatura e cifratura deterministica
-        - decifatura e cifratura randomizzata
+        - decifratura e cifratura deterministica
+        - decifratura e cifratura randomizzata
         - sicurezza per mandare messaggi
         - problemi
     - sicurezza Semantica

--- a/docs/laurea-magistrale/ingegneria-telecomunicazioni.md
+++ b/docs/laurea-magistrale/ingegneria-telecomunicazioni.md
@@ -16,7 +16,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 ### Francesco Pupo
 
-**<u>2020/2021</u>**
+**<u>2020 2021</u>**
 
 - Anonimi
     - Commitment
@@ -35,7 +35,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - a che livelli possiamo fare un attacco e quali sono i costi
     - quali sono gli attacchi a livello software
     - perché è meglio usare protocolli standard rispetto quelli custom
-    - parlare delle crittografia a curve ellittiche
+    - parlare della crittografia a curve ellittiche
     - differenza curve ellittiche e aes
     - algoritmo di hellman
     - block chain e iot come si possono collegare
@@ -64,7 +64,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - come riconosci un EPROM, quali sono i pin di un EPROM SPI
     - a cosa serve il marcatore sui chip integrati
     - come collegarsi agli spi, mqtt è un protocollo affidabile?
-    - cross compilation cos'è, che cos'è una sessione nel protoccolo mqtt
+    - cross compilation cos'è, che cos'è una sessione nel protocollo mqtt
     - differenza durable session e non durable session in mqtt
     - a che serve firmadyne
     - come riconosciamo una uart

--- a/docs/laurea-triennale/ingegneria-biomedica.md
+++ b/docs/laurea-triennale/ingegneria-biomedica.md
@@ -77,7 +77,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - ciclo dell'urea
     - struttura secondaria delle proteine
     - come si raggruppano gli amminoacidi
-    - fosforillazione ossidativa
+    - fosforilazione ossidativa
     - spettrofotometro
     - quanti gruppi di amminoacidi ci sono e quali sono
     - visualizzazione della catena amminoacidica

--- a/docs/laurea-triennale/ingegneria-elettronica.md
+++ b/docs/laurea-triennale/ingegneria-elettronica.md
@@ -34,7 +34,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 - Anonimi
     - Incidenza normale su un buon conduttore
-    - dimostrazione angolo di totale trasmissione di un onda obliqua
+    - dimostrazione angolo di totale trasmissione di un'onda obliqua
     - potenza onda obliqua
     - densità di potenza
 
@@ -103,7 +103,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - problema del differenziale di una funzione in una variabile
     - assioma di continuità del campo r
     - differenza tra serie e integrali
-    - teorema di weiestrass
+    - teorema di Weierstrass
     - teorema fondamentale del calcolo integrale
     - teorema dell'unicità del limite
 
@@ -136,5 +136,5 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 - Anonimi
     - condensatore e conduttori in forma fasoriale
-    - teorema norton
-    - teorema tevenin
+    - teorema di Norton
+    - teorema di Thévenin

--- a/docs/laurea-triennale/ingegneria-informatica.md
+++ b/docs/laurea-triennale/ingegneria-informatica.md
@@ -91,7 +91,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
         - [Sciunzi Berardino](#sciunzi-berardino-1)
         - [Ciolli Fabio](#ciolli-fabio)
     - [Analisi Matematica 2](#analisi-matematica-2)
-        - [Sciuzi Berardino](#sciuzi-berardino)
+        - [Sciunzi Berardino](#sciunzi-berardino-2)
         - [Colao](#colao)
         - [De Luca](#de-luca)
         - [Viviana Solferino](#viviana-solferino)
@@ -197,7 +197,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 **<u>2024 2025</u>**
 
-- Anonimo 1
+- Anonimo
     - Tipi di Validation
     - KNN
     - Varianti del KNN
@@ -258,8 +258,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - Sequential covering
     - Valutazione di un classificatore
     - F-Measure
-    - perchè introduciamo la precision e la recall
-    - Campionamento
+    - perché introduciamo la precision e la recall
     - Clustering gerarchico
     - Algoritmo di Hunt
     - Come scegliere il criterio di split sugli alberi
@@ -268,9 +267,9 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - Come assegnare i punti al cluster più vicino
     - Come aggiornare i centroidi
     - Pseudocodice
-    - Complessita
+    - Complessità
     - Campionamento
-    - Perche si usa
+    - Perché si usa
     - Criterio con il quale si campiona
 
 ## Laboratorio di Sistemi Informativi
@@ -303,17 +302,17 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - xml-schema
     - Insomma può chiedere veramente di tutto ma è molto buono fa tante domande finché non sai qualcosa
     - l'importante è fare il sito(o altro progetto) che rispetta la parte che hai deciso di implementare
-    - ha chiesto a tutti inoltre se avevamo messo controlli sui campi di inserimento quindi controlli per vedere se un email è ben formata durante la registrazione etc
+    - ha chiesto a tutti inoltre se avevamo messo controlli sui campi di inserimento quindi controlli per vedere se un'email è ben formata durante la registrazione etc
     - l'unica cosa è vedere bene sql perché ti fa fare in diretta query ricorsive e trigger
     - Schema a stella e fiocco di neve
         - come suddividere gli attributi in quello a fiocco di neve
 - Giacomo
     - Fase di assestment
-        - cos'é il project managament (visto che quando ho risposto ho detto che ne fa parte)
+        - cos'è il project management (visto che quando ho risposto ho detto che ne fa parte)
     - Cosa é il Work breakdown structure
     - Cosa é il DFM dimensional fact model
     - Costruisci una query ricorsiva che calcoli il fattoriale
-    - Costruisci una query ricorsiva che percorre un grafo a partire dal nodo iniziale(applicato a diversi contesti, cittá, treni etc)
+    - Costruisci una query ricorsiva che percorre un grafo a partire dal nodo iniziale(applicato a diversi contesti, città, treni etc)
     - Operatori OLAP dice e slice
         - se io faccio k operazioni di slice le mie dimensioni dell'ipercubo di quanto variano?
         - La risposta é che se si effettuano k slice allora se la dimensione era n poi sará n-k
@@ -372,7 +371,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 - Salvatore Riga
     - come srotolare una ricorsione
-    - teorema delle ricorrenze per il calcolo della complessita
+    - teorema delle ricorrenze per il calcolo della complessità
 
 **<u>Anno non classificato</u>**
 
@@ -414,7 +413,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 
 - Anonimi
     - Kruskal
-        - complessita spiegata
+        - complessità spiegata
     - Struttura union find e due implementazioni
     - Heap descrizione e inserimento nodo ed estrazione
 
@@ -561,7 +560,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - Teorema del valore iniziale e finale con dimostrazione
     - Modi di evoluzione libera
     - Da una fdt calcola i modi di evoluzione libera
-    - Criterio di routh
+    - Criterio di Routh
     - Bibo stabilità con dimostrazione necessaria e sufficiente
     - Teorema della risposta armonica
     - Forma di Bode
@@ -605,8 +604,8 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 - Enri
     - Sistemi del I e del II ordine
     - Legame tra tempo di salita e banda passante.
-    - Esercizio su carateristiche dei diagrammi di Bode
-    - disegno approsimativo di un sistema del primo ordine a fase non minima
+    - Esercizio su caratteristiche dei diagrammi di Bode
+    - disegno approssimativo di un sistema del primo ordine a fase non minima
 
 **<u>2015 2016</u>**
 
@@ -728,7 +727,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - algoritmi scheduling cpu
         - come si ottimizza il tempo di attesa?
         - come si calcola la stima?
-    - come si muovono i process isu windows?
+    - come si muovono i processi su windows?
     - MMU
     - sostituzione pagine LRU
     - lettori scrittori con semafori come si muovono?
@@ -804,7 +803,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - File System
     - Se collego una tastiera nuova ad un pc vecchio come fa a riconoscerlo (sottosistema di IO )
     - Ready queue e code multiple
-    - paginazione su richiesta come avviena
+    - paginazione su richiesta come avviene
     - sistemi real-time in generale
     - scheduling EDF dei sistemi realtime
     - Disegno dell'architettura della paginazione
@@ -857,7 +856,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 **<u>Anno non classificato</u>**
 
 - Luigi De Marco
-    - Come Linux implementasse non ricordo che, forse la gestione dei processi, e sicuramente come vengono gestita la priorita' tra processi real time e no, non ricordo dove xD
+    - Come Linux implementasse non ricordo che, forse la gestione dei processi, e sicuramente come vengono gestite le priorità tra processi real time e no, non ricordo dove xD
 
 ### Marozzo
 
@@ -909,7 +908,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - monitor di hansen e hoare
     - dati tre thread **a** **b** e **c** fermi su delle istruzioni dire comportamento secondo Hansen, Hoare e in java
     - Cosa fa la yield e perché non va usata
-    - cosa fa la set priority e perchè non va usata
+    - cosa fa la set priority e perché non va usata
     - legge di Amdhal
     - Legge di Moore
     - Barbiere addormentato
@@ -984,7 +983,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - differenza tra hashmap concorrente e sincronizzata
     - cosa vuol dire rientrante per i lucchetti
     - monitor nativi
-    - grafo allocazione delle risorse e condizioni affinche ci sia deadlock
+    - grafo allocazione delle risorse e condizioni affinché ci sia deadlock
     - implementare una sequenza simile a quelle viste a lezione (abc abbc abbbc ...)con i semafori
     - implementare una soluzione al problema dei 5 filosofi che non ammetta starvation (è ammesso im deadlock )
     - implementare una soluzione ai 5 filosofi senza deadlock
@@ -994,7 +993,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - lamport , dijkstra e peterson
     - come funziona la fairness dei semafori e dei lock
     - contrario di fairness? (barging)
-    - perche non basta la fairness dei lock e dobbiamo usare anche le linkedlist
+    - perché non basta la fairness dei lock e dobbiamo usare anche le linkedlist
     - legge di Amdahl e considerazioni casi limite
     - differenza tra processo e thread
     - code associate ai monitor come funzionano? (diff hansen e hoare)
@@ -1098,7 +1097,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - schedule serializzabile
     - protocollo 2pl
     - condizione di recuperabilità
-    - strong e stong strict 2pl
+    - strong e strong strict 2pl
     - esempio di schedule serializzabile ma non view
 
 **<u>2023 2024</u>**
@@ -1113,7 +1112,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - serializzabilità
     - Esempio di schedule view-serializable ma non conflict-serializable
     - esempio di schedule serializable ma non view-serializable
-    - Quando uno schedule è serializabile
+    - Quando uno schedule è serializzabile
     - Dimostrazione two face looking implica conflict serializable
     - Scrivere schedule non view serializable ma serializzabile
     - Scrivere schedule non conflict serializable ma view serializable
@@ -1142,10 +1141,10 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - condizione per essere serializzabile
     - schedule cascadeless e recoverable
 - Anonimi
-    - chiede due domende tra le tre essenziali :
+    - chiede due domande tra le tre essenziali :
         - dipendenza funzionale
         - chiave primaria
-        - chiave candidat
+        - chiave candidata
     - differenza tra bree e bplus tree
 - Giovanni Giordano
     - quando due schedule sono serializzabili
@@ -1157,7 +1156,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - Schedule serializzabile
     - schedule seriale
     - Phantom read
-    - dimostrazione 2pl implica confict equivalence
+    - dimostrazione 2pl implica conflict equivalence
 
 **<u>2017 2018</u>**
 
@@ -1168,9 +1167,9 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - schedule con proprietà recoverable e cascadeless
 - Simone
     - tecnica di hashing statico e indirizzamento aperto
-    - Esempio di schedule view serializzable ma non confict serializzable
+    - Esempio di schedule view serializzable ma non conflict serializzable
 - Francesco
-    - serializzabilita
+    - serializzabilità
     - esempio schedule view serializzable ma non conflict serializzable
     - 2PL cosa implica
     - cascadeless con esempio
@@ -1256,7 +1255,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 **<u>2023 2024</u>**
 
 - Anonimi
-    - Una delle tre fefinizioni formali tra chiave candidata, chiave esterna e schedule serializzabile ( Se capitate con nardiello imparare l'esatte parole del libro formali o vi boccia anche se sapete il concetto )
+    - Una delle tre definizioni formali tra chiave candidata, chiave esterna e schedule serializzabile ( Se capitate con nardiello imparare l'esatte parole del libro formali o vi boccia anche se sapete il concetto )
     - Rimozione di una chiave in un b-tree
     - Struttura di un nodo di un b-tree
     - Differenza tra hashing statico e dinamico
@@ -1403,7 +1402,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
     - Amministrazione linux
     - mount
 - Arbrane97
-    - cosa è una sistem call
+    - cosa è una system call
     - repository
     - fstab
 
@@ -1510,7 +1509,7 @@ Leggi il nostro [README](https://github.com/UnicalLoveTelegram/IndiceArgomentiOr
 - Anonime
     - Gestioni permessi
     - Software libero e licenze
-    - ouput di un prgramma C
+    - output di un programma C
     - errore in questo programma
 
 ```c
@@ -1562,7 +1561,7 @@ malloc(sizeof(int)*(i+1));
     - Come gestire un file che dobbiamo salvare in locale( tipo invece di firebase in locale)
     - Riverpod a che serve
     - I widget come funzionano
-    - Isolates perche lo usiamo
+    - Isolates perché lo usiamo
     - Class extension di dart
 
 ## Chimica
@@ -1723,7 +1722,7 @@ malloc(sizeof(int)*(i+1));
     - Quali pattern abbiamo visto a lezione
     - A quale pattern associ l'executor framework
     - Tipi di comunicazione GRPC
-    - Tipi di comunicazione, asincorna e sincrona
+    - Tipi di comunicazione, asincrona e sincrona
     - Cosa fa git rebase
     - Come mantiene le versioni git e quanto è lungo lo sha-1
     - Come avviene la merge in git
@@ -1825,7 +1824,7 @@ malloc(sizeof(int)*(i+1));
     - Quali pattern abbiamo visto a lezione
     - A quale pattern associ l'executor framework
     - Tipi di comunicazione GRPC
-    - Tipi di comunicazione, asincorna e sincrona
+    - Tipi di comunicazione, asincrona e sincrona
     - Cosa fa git rebase
     - Come mantiene le versioni git e quanto è lungo lo sha-1
     - Come avviene la merge in git
@@ -1990,7 +1989,7 @@ malloc(sizeof(int)*(i+1));
     - Spiegare la differenza tra multiplexing TCP e UDP
     - Differenza tra risoluzione iterative e ricorsiva del DNS
         - Quale delle due è la soluzione più vantaggiosa ?
-    - ICMP cos è?
+    - ICMP cos'è?
     - Traceroute funzionamento, cosa sono gli asterischi che possono uscire in un traceroute
     - A che serve una CA?
         - Cosa troviamo dentro una CA
@@ -1998,14 +1997,14 @@ malloc(sizeof(int)*(i+1));
     - Perché la ricerca è in log_2 in chord
     - Quanti sono i successori nella lista di successori in chord?
     - Cosa ci permette di fare il gateway a livello applicazione che il firewall a filtraggio di pacchetto non permette?
-    - Hot potato routing cos è, è intra-AS o inter-AS ?
-    - FIREWALL: Perchè è necessario nel filtraggio di pacchetto un ordine ragionato e non randomico ?
+    - Hot potato routing cos'è, è intra-AS o inter-AS?
+    - FIREWALL: Perché è necessario nel filtraggio di pacchetto un ordine ragionato e non randomico?
     - Quale regola inseriamo per bloccare le connessioni in ingresso TCP?
     - Perché sarebbe sbagliato bloccare i pacchetti in ingresso con solo SYN pari a 1?
     - Come funziona la sostituzione poli-alfabetica?
     - KDC come funziona ?
     - FTP
-    - Che cos è la GET condizionale?
+    - Che cos'è la GET condizionale?
     - Differenza tra stop & Wait e Pipeline
     - Differenza tra selective e go back n e vantaggi e svantaggi
     - MAC codice di autenticazione
@@ -2092,7 +2091,7 @@ malloc(sizeof(int)*(i+1));
     - schema di una rete chord con spiegazione
     - confrontare gli approcci p2p (con indice centrale, query flooding, dht)
     - p2p approcci. Esistono p2p puri?
-    - Bittorent dire cosa sono leecher e seeder e poi spiegare tutto il resto
+    - BitTorrent dire cosa sono leecher e seeder e poi spiegare tutto il resto
     - risoluzione iterativa e ricorsiva del dns
     - disegnare il grafico del provisioning delle risorse e spiegare le differenze tra underprovisioning, overprovisioning e cosa succede nel cloud computing
     - http 2.0
@@ -2118,10 +2117,9 @@ malloc(sizeof(int)*(i+1));
 ### Cristian Cosentino
 
 - Anonimi
-    - esercizio scrivere un client che riceve un orario tramite udo
+    - esercizio scrivere un client che riceve un orario tramite UDP
     - port forwarding
     - cloud computing
-    - nat
     - esercizio implementare una chat fra client e server
     - Prendere l'header da una pagina
     - Prendere il contenuto della pagina
@@ -2197,9 +2195,9 @@ malloc(sizeof(int)*(i+1));
     - simulazione montecarlo (origini del nome + tempo medio di attesa in coda + intervallo di confidenza + cos'è l' IC e per cosa nasce)
     - funzione tempo di attesa (forma generale e non)
     - varianza campionaria
-    - problema di sincronia (usando problema del ritardo del professore, considera ritardo del prof e degli studenti + individuare l'areache corrisponde ad evento di interesse " lo studente arriva dopo il professore" + adattando funz di densità lineare, ma compresa tra 0 e 20 per il ritardo del prof, calcolare la probabilità dell'eventodi interesse)
+    - problema di sincronia (usando problema del ritardo del professore, considera ritardo del prof e degli studenti + individuare l'area che corrisponde ad evento di interesse "lo studente arriva dopo il professore" + adattando funz di densità lineare, ma compresa tra 0 e 20 per il ritardo del prof, calcolare la probabilità dell'eventodi interesse)
     - info su lezione 22 , parte 1 e 2 (ricordarsi che la 2^ parte del corso inizia da lez 20)
-    - quesito di probabilistica fornito dal prof (approccio alternativo usando la congiunta
+    - quesito di probabilistica fornito dal prof (approccio alternativo usando la congiunta)
     - domanda basata su slide lez 27.1 (ricordarsi metodo m - c)
     - differenza tra equazioni equiprobabili ed equidistanti (spiegare come se fossi tu ad insegnare l'argomento alla classe, prof incluso, perché ci tiene + guardare le slide in diretta e farsi domande su ciò che è scritto, anche se ciò che è scritto non è stato spiegato dal prof, e spiegarlo)
     - spiegare cos'è un problema di sincronia( +"capire cosa si sta spiegando" + spiegare il ritardo di sincronia)
@@ -2217,7 +2215,7 @@ malloc(sizeof(int)*(i+1));
 **<u>2017 2018</u>**
 
 - Giovanni
-    - Staistica ordinamento
+    - Statistica ordinamento
     - metodo montecarlo
 - Anonimi
     - correlazione
@@ -2246,12 +2244,12 @@ malloc(sizeof(int)*(i+1));
         - probabilita
         - successo
         - guasto del 3 server con la geometrica
-        - coefficente di pearson
+        - coefficiente di Pearson
     - modello PC e considerazioni sul tempo di giacenza e tempo di soggiorno
         - perché il tempo di giacenza è più influente?
         - calcoli su excel
     - modello di erlang e considerazioni sui grafici della erlang modulata
-    - dimostrazione coefficenti della retta di regressioe
+    - dimostrazione coefficienti della retta di regressione
     - valore atteso e distribuzione esponenziale
     - diapositiva regressione
     - esercizio su erlang con bernoulli
@@ -2260,7 +2258,7 @@ malloc(sizeof(int)*(i+1));
     - statistiche di ordinamento
     - esercizio su m out of n e commutazione
     - foglio excel della correlazione produttore consumatore
-    - dimostrazione coefficenti della retta di regressione
+    - dimostrazione coefficienti della retta di regressione
     - funzioni di v.a.
     - statistiche min e Max con funzione di distribuzione
     - modello di erlang
@@ -2288,10 +2286,10 @@ malloc(sizeof(int)*(i+1));
     - leggi di snell
     - soluzioni viaggianti e soluzioni stazionarie
     - intervallo di variazione
-    - polarizzazione di un onda
+    - polarizzazione di un'onda
     - linea adattata comportamenti di tensione e corrente
     - mezzi con perdite
-    - derivata teporale della prima equazione di maxwell e dimostrazione legge di Faraday
+    - derivata temporale della prima equazione di Maxwell e dimostrazione legge di Faraday
     - tipi di adattamento come si collega lo stub
     - circuitazione
 
@@ -2338,7 +2336,7 @@ malloc(sizeof(int)*(i+1));
         - un esempio di unica soluzione ottima
         - infinite soluzioni ottime ( la soluzione sta tra due vertici, i punti son di base e ciò che sta in mezzo non di base )
         - fare di entrambi la funzione obiettivo
-    - cosa sono i coefficenti ridotti e come ricavarli
+    - cosa sono i coefficienti ridotti e come ricavarli
     - definizione di soluzione di base
     - quando è più facile risolvere il PLI rispetto a PL
     - disegnare regione ammissibile PLI
@@ -2363,7 +2361,7 @@ malloc(sizeof(int)*(i+1));
     - matrici tum
     - teorema fondamentale PL
     - ipotesi della PL
-        - `[ε1,ε2]` una delle due può essere finita, dal punto di vista geometrico qual'è il significato
+        - `[ε1,ε2]` una delle due può essere finita, dal punto di vista geometrico qual è il significato
         - riposta: una è infinita quando la regione ammissibile è illimitata ( ci son altri esempi)
     - teorema debole e forte
     - formula del duale
@@ -2487,13 +2485,13 @@ malloc(sizeof(int)*(i+1));
 
 **<u>2015 2016</u>**
 
-- Utenti Anonimi e testimonianze
+- Anonimi
     - Demux, schema interno
     - Ram definizione e schema di una cella
     - come si usano i flag assembly
     - principio di dualità
     - definizione di implicante primo
-    - operatori funzionamente completi
+    - operatori funzionalmente completi
     - differenza tra mul e imul
     - sistema controllo cablato
     - esercizio: quadword in due registri
@@ -2512,7 +2510,7 @@ malloc(sizeof(int)*(i+1));
     - livello dei circuiti
     - mux
     - ram
-    - macchina a regisri ( registro lr a 64bit con fetch )
+    - macchina a registri ( registro lr a 64bit con fetch )
     - MBR
     - Mappa di karnaugh
     - Meccanismo interruzione
@@ -2559,10 +2557,10 @@ malloc(sizeof(int)*(i+1));
 ### Ciolli Fabio
 
 - Anonimo
-    - rolle
-    - weierstrass
-    - cauchy
-    - lagrange
+    - Rolle
+    - Weierstrass
+    - Cauchy
+    - Lagrange
     - condizione necessaria di convergenza
     - convergenza integrali assoluta
     - confronto asintotico integrali
@@ -2572,8 +2570,8 @@ malloc(sizeof(int)*(i+1));
     - leibniz
     - criterio del rapporto
     - criterio della radice
-    - fermat
-    - bolzano weierstrass
+    - Fermat
+    - Bolzano-Weierstrass
     - valori medi
     - convergenza assoluta integrali impropri
     - criterio del confronto
@@ -2652,35 +2650,35 @@ malloc(sizeof(int)*(i+1));
     - Derivata e^sin
     - Fermat
 - Anonimi
-    - Fare la derivata di un logaritmo composto con il cosenz
+    - Fare la derivata di un logaritmo composto con il coseno
     - Teorema di Lagrange con dimostrazione
-    - Teorema della sviluppabilità in serie di Taylod con dimostrazione
+    - Teorema della sviluppabilità in serie di Taylor con dimostrazione
     - Teorema della permanenza del segno con dimostrazione
 
 ## Analisi Matematica 2
 
-### Sciuzi Berardino
+### Sciunzi Berardino
 
 **<u>2017 2018</u>**
 
 - FrancescoLux
-    - teorema moltiplicatori di lagrange
-    - teorema di liouville
+    - teorema moltiplicatori di Lagrange
+    - teorema di Liouville
 - Giovanni Giordano
-    - teorema moltiplicatori lagrange
+    - teorema moltiplicatori di Lagrange
     - teorema dei residui
-- Anonime:
-    - liouville
+- Anonime
+    - Liouville
     - teorema residui
     - integrali curvilinei complessi
-    - dini
+    - Dini
     - c1 implica differenziabilita
     - serie di fourier
 
 **<u>2016 2017</u>**
 
 - Anonimi
-    - Teorema moltiplicatori di lagrange
+    - Teorema moltiplicatori di Lagrange
     - Max modulo
     - spazio in R2
     - prodotto scalare e norma
@@ -2690,11 +2688,11 @@ malloc(sizeof(int)*(i+1));
     - convergenza puntuale uniforme
     - Liuoville
     - base della serie di fourier
-    - teorema di dini
-    - teorema di cauchy
+    - teorema di Dini
+    - teorema di Cauchy
     - teorema di unicità
-    - come si ricavano le condizioni di cauchy Riemann
-    - integrale di superfice
+    - come si ricavano le condizioni di Cauchy-Riemann
+    - integrale di superficie
 
 ### Colao
 
@@ -2713,7 +2711,7 @@ malloc(sizeof(int)*(i+1));
     - perché rho tende a zero mentre theta non lo fa
     - risolvere un problema di Cauchy con lo schema di Eulero
     - come un calcolatore risolve le equazioni differenziali?
-    - Dimostrare perché una equazione differenziale lineare con coefficenti f(x) costanti ha sempre una soluzione e quindi la condizione di Lipschitzianità vale sempre
+    - Dimostrare perché una equazione differenziale lineare con coefficienti f(x) costanti ha sempre una soluzione e quindi la condizione di Lipschitzianità vale sempre
     - teorema del rotore
     - limiti in coordinate polari
     - chiede esercizi vari e soprattutto fate attenzione che può chiedere esercizi fatti agli appelli all'orale
@@ -2734,8 +2732,8 @@ malloc(sizeof(int)*(i+1));
     - controllare se date due equazioni differenziali sono linearmente indipendenti
         - in caso affermativo trovare una soluzione ode che soddisfi queste sue soluzioni
     - data una figura aperta calcolare il flusso
-    - teorema di cauchy riemann con dimostrazione
-    - dimostrare che le condizioni di cauchy riemann sono armoniche coniugate
+    - teorema di Cauchy-Riemann con dimostrazione
+    - dimostrare che le condizioni di Cauchy-Riemann sono armoniche coniugate
     - data la funzione f(x,y)=y²e^x vedere se è differenziabile ed eventuali punti di massimo, minimo o sella
     - data una superficie posta solo sul piano xy quindi con versore normale diretto lungo z e dato un campo vettoriale F=(x,y,z) trovare il flusso attraverso tale superficie (fa 0)
     - dati y1=e^3x ed y2=e^-3x verificare se fossero l.i. e trovare un'ode omogenea di cui fossero soluzione
@@ -2744,11 +2742,11 @@ malloc(sizeof(int)*(i+1));
 **<u>2017 2018</u>**
 
 - Anonimi
-    - calcolo del lavoro in un campo vetoriale data una curva qualsiasi e due punti
+    - calcolo del lavoro in un campo vettoriale data una curva qualsiasi e due punti
     - irrotazionalità e campo conservativo
     - definizione di rotore e uso
-    - data un equazione differenziale che la soluzione in un punto dato
-    - verificare data un eq differenziale che la soluzione in un punto dato è unica (verifica della lipchitzianità)
+    - data un'equazione differenziale che la soluzione in un punto dato
+    - verificare data un'eq differenziale che la soluzione in un punto dato è unica (verifica della lipschitzianità)
 
 ### Viviana Solferino
 
@@ -2927,7 +2925,7 @@ malloc(sizeof(int)*(i+1));
 - Anonimo
     - cos'è una formula soddisfacibile?
     - cos'è una tautologia?
-    - modus ponens, tollendo tones
+    - modus ponens, tollendo tollens
     - A implica B or C or D implica Z, cos'è?
     - A implica B che implica C, cos'è?
     - cos'è una formula ambigua? +esempio
@@ -3008,7 +3006,7 @@ malloc(sizeof(int)*(i+1));
     - Che cosa è il principio di induzione ?
     - Calcolo combinatorio in generale
     - Disposizioni con ripetizione
-    - Che cos' è una base di uno spazio vettoriale?
+    - Che cos'è una base di uno spazio vettoriale?
     - Come si può costruire una base per uno spazio vettoriale
     - Se abbiamo i vettori e vogliamo completare la base?
         - anche processo inverso
@@ -3017,16 +3015,16 @@ malloc(sizeof(int)*(i+1));
     - Combinazione lineare
     - Metodi di dimostrazione
     - Leggi di De Morgan
-    - Che cosa sono i diagrammi di Venezia
+    - Che cosa sono i diagrammi di Venn
     - Disegni un insieme B tale che l'intersezione non sia vuota
     - Disegni il complementare all'unione di due insiemi
     - Che cosa sono autovalori autovettori ed endomorfismo
     - Molteplicità algebriche e geometriche di un autovalore
     - Che cosa sono le combinazioni semplici ?
-    - Rocche Capelli teorema
+    - Teorema di Rouché-Capelli
     - Cosa è e come si calcola il determinante
     - Proprieta determinante
-    - Regola del prodotto o della somma del calcolo combiantorio
+    - Regola del prodotto o della somma del calcolo combinatorio
     - Spazi lineari dei polinomi
     - Differenze tra combinazioni con e senza ripetizioni
     - Che cosa e uno spazio vettoriale?
@@ -3034,7 +3032,7 @@ malloc(sizeof(int)*(i+1));
     - legame elementi di pivot e determinati
     - Base di uno spazio di polinomi
     - Una base infinita
-    - In che modo e legato il calcolo combiantorio al calcolo del determinante
+    - In che modo e legato il calcolo combinatorio al calcolo del determinante
     - Teorema degli orlati
     - Matrice quadrata invertibile e trovare la sua inversa
     - Numero di combinazioni semplici
@@ -3052,14 +3050,14 @@ malloc(sizeof(int)*(i+1));
     - Dimostrazione per contrapposizione
     - che cosa sono gli spazi euclidei
     - Che funzione deve essere definita su spazi euclidei?
-    - Come si può affermare un affermazione universale
+    - Come si può affermare un'affermazione universale
     - Applicazioni lineari
     - Differenza metodo, contrapposizione e assurdo
     - Assiomi di piano
     - perché la radice di 2 non è razionale
     - Teorema dimensioni
     - Che cosa è il ker
-    - iniettivitità,suriettività e bigettività
+    - iniettività, suriettività e biiettività
     - Rango di una matrice
 
 **<u>2017 2018</u>**
@@ -3111,7 +3109,7 @@ malloc(sizeof(int)*(i+1));
 **<u>2025 2026</u>**
 
 - Anonimo
-    - Cosa sono autovaloei e autovettori
+    - Cosa sono autovalori e autovettori
     - Matrice diagonale e diagonalizzante
     - Dimensione base
     - Quando facciamo C^-1 per un vettore cosa otteniamo?
@@ -3197,7 +3195,7 @@ malloc(sizeof(int)*(i+1));
     - Primo principio della termodinamica + Primo principio della Termodinamica associato alle trasformazioni (Penny)
     - Moto parabolico
     - Momento di inerzia per massa puntiforme e per massa estesa
-    - Condizioni affinchè un corpo sia in equilibrio
+    - Condizioni affinché un corpo sia in equilibrio
     - Calore specifico
     - Impulso
     - Oscillatore armonico
@@ -3210,7 +3208,7 @@ malloc(sizeof(int)*(i+1));
     - Accelerazione centripeta
     - Classificazione degli urti
     - Gas Perfetti
-    - Perchè si dice moto parabolico?
+    - Perché si dice moto parabolico?
     - Momento della Quantità
 
 **<u>2023 2024</u>**
@@ -3243,9 +3241,19 @@ malloc(sizeof(int)*(i+1));
 
 ### Marco Schioppa
 
-**<u>2025/2026</u>**
+**<u>2025 2026</u>**
 
-- nncbtv e Anonimi - Discussione errori compito - Spiegare cos'è il lavoro e l'energia - Definizione del lavoro tramite integrale - Teorema dell'energia cinetica - Energia potenziale elastica - Trasformazione Isoterma - Trasformazione Adiabatica - Corpo rigido - Quando una forza si dice conservativa - Legge dei gas perfetti
+- nncbtv e Anonimi
+    - Discussione errori compito
+    - Spiegare cos'è il lavoro e l'energia
+    - Definizione del lavoro tramite integrale
+    - Teorema dell'energia cinetica
+    - Energia potenziale elastica
+    - Trasformazione Isoterma
+    - Trasformazione Adiabatica
+    - Corpo rigido
+    - Quando una forza si dice conservativa
+    - Legge dei gas perfetti
 
 ## Robotica
 
@@ -3299,7 +3307,7 @@ malloc(sizeof(int)*(i+1));
     - pacchetto TCP e UDP (con differenze)
     - multiplexing e demultiplexing
     - tecniche di accesso multiplo
-    - fast recovery e retrasmit
+    - fast recovery e retransmit
 - Anonimo
     - Protocolli arq con dimostrazione di utilizzazione e efficienza
         - con e senza errori
@@ -3329,13 +3337,13 @@ malloc(sizeof(int)*(i+1));
     - karn
     - SRTT
 - Anonimi
-    - fast retrasmitt
+    - fast retransmit
     - fast recovery
 
 **<u>2017 2018</u>**
 
 - Anonimi
-    - fast retrasmitt e fast recovery
+    - fast retransmit e fast recovery
     - perché nel calcolo RTT si tiene conto della deviazione media
     - Cosa succede ad RTT in caso di reti lente rispetto a veloci
 
@@ -3355,7 +3363,7 @@ malloc(sizeof(int)*(i+1));
 - Martorello96
     - Teo di parseval
     - shannon
-    - algoritmo di gram shmit
+    - algoritmo di Gram-Schmidt
     - interferenze
     - intersimbolo con criterio di nyquist
     - criteri di decisione
@@ -3402,7 +3410,6 @@ malloc(sizeof(int)*(i+1));
     - IPSEC
     - Differenza tra IntServ e DiffServ
     - IPv4 e IPv6
-    - IPv4 e IPv
 
 ## Laboratorio di ricerca operativa
 
@@ -3432,7 +3439,7 @@ malloc(sizeof(int)*(i+1));
 - Zio Rob
     - BSP in generale
     - Esempi pratici di BSP (GraphX)
-    - cos è una EdgeTriplet
+    - cos'è una EdgeTriplet
     - UPC++ e il metodo Monte Carlo per piGreco
     - PGAS
         - APGAS


### PR DESCRIPTION
## Cosa cambia

Risolto typo nel testo e problemi di consistenza nello stile del testo

## Checklist

- [x] Ho formattato i file Markdown con `make lint-fix` o `mdformat --extensions space_control --no-validate`.
- [x] Ho evitato tab e spazi finali.
- [x] Ho verificato la formattazione con `make lint` o con `mdformat --extensions space_control --check docs/ README.md CONTRIBUTING.md`.
- [ ] Se ho aggiunto o rinominato pagine, ho aggiornato anche `mkdocs.yml`.
